### PR TITLE
feat: add cd command as builtin with - ~ and error handlings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ unix-shell/
 ## Kullanılan Sistem Programlama Kavramları
 
 - **Process management**: `fork()`, `execvp()`, `waitpid()`, `_exit()`
-- **System calls / POSIX API**: `isatty`, `getpid`, `localtime_r`, `strerror`
+- **System calls / POSIX API**: `isatty`, `getpid`, `localtime_r`, `strerror`, `chdir`, `getcwd`, `getenv`, `setenv`
 - **Senkronizasyon**: `pthread_mutex_lock/unlock` (log dosyası için)
 - **Hata yönetimi**: `errno`, `perror`, log dosyasına seviye etiketli
   (`INFO`, `WARN`, `ERROR`) kayıt

--- a/include/executor.h
+++ b/include/executor.h
@@ -1,6 +1,7 @@
 #ifndef MSH_EXECUTOR_H
 #define MSH_EXECUTOR_H
 
+int run_builtin(char **argv);
 int run_external(char **argv);
 
 #endif

--- a/src/executor.c
+++ b/src/executor.c
@@ -11,6 +11,62 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+static int builtin_cd(char **argv)
+{
+    const char *target = NULL;
+
+    if (argv[1] == NULL || strcmp(argv[1], "~") == 0) {
+        target = getenv("HOME");
+        if (target == NULL) {
+            fprintf(stderr, "cd: HOME not set\n");
+            log_msg("ERROR", "cd: HOME not set");
+            return -1;
+        }
+    } else if (strcmp(argv[1], "-") == 0) {
+        target = getenv("OLDPWD");
+        if (target == NULL) {
+            fprintf(stderr, "cd: OLDPWD not set\n");
+            log_msg("ERROR", "cd: OLDPWD not set");
+            return -1;
+        }
+        printf("%s\n", target);
+    } else {
+        target = argv[1];
+    }
+
+    char old_cwd[4096];
+    if (getcwd(old_cwd, sizeof(old_cwd)) == NULL) {
+        perror("cd: getcwd");
+        log_msg("ERROR", "cd: getcwd failed: %s", strerror(errno));
+        return -1;
+    }
+
+    if (chdir(target) < 0) { // Change Directory
+        perror("cd");
+        log_msg("ERROR", "cd '%s' failed: %s", target, strerror(errno));
+        return -1;
+    }
+
+    log_msg("INFO", "cd '%s'", target);
+
+    if (setenv("OLDPWD", old_cwd, 1) < 0) {
+        perror("cd: setenv OLDPWD");
+        log_msg("ERROR", "cd: setenv OLDPWD failed: %s", strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
+int run_builtin(char **argv)
+{
+    if (strcmp(argv[0], "cd") == 0) {
+        builtin_cd(argv);
+        return 1;
+    }
+    return 0;
+}
+
 int run_external(char **argv)
 {
     pid_t pid = fork();

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #define MAX_LINE 1024
@@ -36,6 +37,10 @@ int main(void)
         }
 
         if (parse_line(line, argv) == 0) {
+            continue;
+        }
+
+        if (run_builtin(argv)) {
             continue;
         }
 


### PR DESCRIPTION
This pull request introduces support for the `cd` built-in command to the shell, allowing users to change directories within the shell session. The implementation includes proper error handling, environment variable management, and updates to documentation to reflect the new and existing system calls.

**New built-in command:**

* Implemented the `cd` built-in command in `src/executor.c`, handling common cases like `cd`, `cd ~`, and `cd -`, with appropriate error messages and environment variable updates (`HOME`, `OLDPWD`).
* Added the `run_builtin` function in `src/executor.c` and its declaration in `include/executor.h` to dispatch built-in commands, currently supporting `cd`. [[1]](diffhunk://#diff-82e93641c69d156d8545fd6e151ae896b218808b8d3d7332ea9faadf0ad738ffR14-R69) [[2]](diffhunk://#diff-ebeeb1fe20145bf0170ddb0dec8614a326c3861d14571e10e490aec2bc6752c5R4)
* Updated the main shell loop in `src/main.c` to check and execute built-in commands before attempting to run external commands.

**Documentation and dependencies:**

* Updated the list of system calls in `unix-shell/README.md` to include `chdir`, `getcwd`, `getenv`, and `setenv`, reflecting the new dependencies introduced by the `cd` command.
* Included the missing `#include <string.h>` in `src/main.c` for string operations used by built-in command handling.