### PR TITLE
feat: add background process execution and SIGCHLD handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Mini Unix Shell (msh)
 
 Bu klasör, "Mini Unix Shell" projesinin **başlangıç sürümünü** içerir.
-Tek seviyeli pipe (`|`) ve built-in komutlar (`cd`, `exit`) eklenmiştir.
+Tek seviyeli pipe (`|`), built-in komutlar (`cd`, `exit`) ve temel
+arka plan süreçleri (`&`) eklenmiştir.
 
 ## Amaç
 
@@ -14,10 +15,21 @@ kurmak ve process yaratma + bekleme akışını sağlam bir şekilde oturtmaktı
 - **REPL (Read-Eval-Print Loop)**:
   1. `fgets` ile satır oku
   2. `|` varsa `parse_pipe` ile iki komuta ayır, `run_pipe` çalıştır
-  3. `strtok` ile tokenize et
+  3. `strtok` ile tokenize et; son token `&` ise argv'den çıkar ve
+     komutu background olarak işaretle
   4. Built-in (`cd`, `exit`) ise built-in çalıştır
-  5. `fork()` → çocukta `execvp()`, ebeveynde `waitpid()`
+  5. Foreground komutta `fork()` → çocukta `execvp()`, ebeveynde `waitpid()`
+  6. Background komutta ebeveyn `waitpid()` yapmaz; sadece `[pid]`
+     yazdırıp prompt'a döner
 - **Pipe**: `pipe()` + iki `fork()` + `dup2` ile tek seviyeli pipeline
+- **Background akışı ve `SIGCHLD`**:
+  1. `SIGCHLD`, `sigaction()` ile kurulmuş handler'a düşer
+  2. Handler içinde yalnızca `waitpid(-1, &st, WNOHANG)` çağrısı ile
+     biten çocuklar reap edilir ve sonuçlar sabit boyutlu kuyruğa bırakılır
+  3. Ana döngü `flush_background_events()` ile bu kuyruğu boşaltır ve
+     log'a `bg cmd bitti pid=N exit=K` satırını yazar
+  4. Foreground `waitpid()` ile yarış olmaması için foreground komutlarda
+     ebeveyn, `SIGCHLD`'yi `sigprocmask()` ile geçici olarak maskeler
 - **Loglama**: tüm olaylar `shell.log` dosyasına zaman damgalı yazılır.
   Log yazımı `pthread_mutex` ile korunur; ileride birden fazla
   thread/child aynı anda loga yazsa bile satırlar bozulmaz.
@@ -36,13 +48,13 @@ unix-shell/
     ├── main.c       # REPL döngüsü
     ├── log.c        # zaman damgalı, mutex'li log dosyası yazımı
     ├── parser.c     # komut satırını argv dizisine ayırma
-    └── executor.c   # fork + execvp + waitpid akışı
+    └── executor.c   # fork + execvp + waitpid + SIGCHLD/reaping akışı
 ```
 
 ## Kullanılan Sistem Programlama Kavramları
 
 - **Process management**: `fork()`, `execvp()`, `waitpid()`, `_exit()`
-- **System calls / POSIX API**: `isatty`, `getpid`, `localtime_r`, `strerror`, `chdir`, `getcwd`, `getenv`, `setenv`, `pipe`, `dup2`, `close`
+- **System calls / POSIX API**: `isatty`, `getpid`, `localtime_r`, `strerror`, `chdir`, `getcwd`, `getenv`, `setenv`, `pipe`, `dup2`, `close`, `sigaction`, `sigprocmask`
 - **Senkronizasyon**: `pthread_mutex_lock/unlock` (log dosyası için)
 - **Hata yönetimi**: `errno`, `perror`, log dosyasına seviye etiketli
   (`INFO`, `WARN`, `ERROR`) kayıt
@@ -69,6 +81,10 @@ msh> uname -a
 Linux ...
 msh> ls | wc -l
 8
+msh> sleep 5 &
+[12345]
+msh> echo prompt geri geldi
+prompt geri geldi
 msh> echo merhaba dunya | tr a-z A-Z
 MERHABA DUNYA
 msh> exit 3       # 3 koduyla çıkış
@@ -99,11 +115,15 @@ Bu sürümde manuel test seti:
 | 14| `ls \|`         | "invalid pipe command" hatasi, shell kapanmaz         |
 | 15| `ls \| cd /tmp`  | cd pipe icinde calisir, ebeveyn dizini degismez     |
 | 16| `echo \| exit 5` | pipe icindeki exit sadece cocuk prosesi oldurur     |
+| 17| `sleep 1 &`      | Prompt hemen doner, `[pid]` yazilir                 |
+| 18| `sleep 1 &` + log| Bitince log'a `bg cmd bitti pid=N exit=0` duser    |
+| 19| `ps -o stat= -p N` | Proses bitince `Z` gorulmez, zombie kalmaz        |
+| 20| `cd /tmp &`      | Built-in background reddedilir, shell calismaya devam eder |
 
 Hızlı toplu test:
 
 ```bash
-printf 'echo merhaba\nls | wc -l\nls | cd /tmp\npwd\nfalse\nyokboyle\nexit 3\n' | ./msh
+printf 'echo merhaba\nsleep 1 &\nls | wc -l\nfalse\nexit 3\n' | ./msh
 cat shell.log
 ```
 
@@ -118,13 +138,17 @@ cat shell.log
   süreç aynı `FILE*`'ye yazacak. Şimdilik `pthread_mutex` ile süreç
   içinden korunuyor, sonraki adımda `flock`/`O_APPEND` davranışı
   da değerlendirilecek.
+- **`SIGCHLD` içinde güvenli işlem**: Handler içinde `printf` veya
+  `log_msg` çağırmak async-signal-safe değil. Bu yüzden handler sadece
+  reaping yapıyor; log yazımı ve kullanıcıya görünür yan etkiler ana
+  döngüde tamamlanıyor.
 - **Boş satır / sadece boşluk**: `parse_line` 0 dönerse `fork`'a hiç
   girilmiyor; aksi halde her enter'da gereksiz process açılırdı.
 
 ## Sonraki Adımlar (TODO)
 
 - [x] `cd` ve `exit` built-in komutlari
-- [ ] Arka plan surecleri (`&`) ve `SIGCHLD` ile reaping
+- [x] Arka plan surecleri (`&`) ve `SIGCHLD` ile reaping
 - [x] Tek seviyeli pipe (`|`) destegi
 - [ ] Son 10 komut icin history
 - [ ] Performans degerlendirmesi (komut basina sure olcumu, ortalamalar)

--- a/include/executor.h
+++ b/include/executor.h
@@ -1,8 +1,10 @@
 #ifndef MSH_EXECUTOR_H
 #define MSH_EXECUTOR_H
 
-int run_builtin(char **argv);
-int run_external(char **argv);
+int install_sigchld_handler(void);
+void flush_background_events(void);
+int run_builtin(char **argv, int background);
+int run_external(char **argv, int background);
 int run_pipe(char **left_argv, char **right_argv);
 
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -3,7 +3,7 @@
 
 #define MAX_ARGS 64
 
-int parse_line(char *line, char **argv);
-int parse_pipe(char *line, char **left_argv, char **right_argv);
+int parse_line(char *line, char **argv, int *background);
+int parse_pipe(char *line, char **left_argv, char **right_argv, int *background);
 
 #endif

--- a/src/executor.c
+++ b/src/executor.c
@@ -3,6 +3,7 @@
 #include "executor.h"
 #include "log.h"
 
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -12,6 +13,69 @@
 #include <sys/wait.h>
 
 static int last_exit_code = 0;
+static sigset_t sigchld_mask;
+
+#define BG_EVENT_CAPACITY 64
+
+static volatile sig_atomic_t bg_head = 0;
+static volatile sig_atomic_t bg_tail = 0;
+static volatile sig_atomic_t bg_overflow = 0;
+static volatile sig_atomic_t bg_pids[BG_EVENT_CAPACITY];
+static volatile sig_atomic_t bg_statuses[BG_EVENT_CAPACITY];
+
+static int status_to_exit_code(int status)
+{
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+        return 128 + WTERMSIG(status);
+    }
+    return 1;
+}
+
+static void enqueue_bg_event(pid_t pid, int status)
+{
+    sig_atomic_t next = (bg_head + 1) % BG_EVENT_CAPACITY;
+
+    if (next == bg_tail) {
+        bg_overflow = 1;
+        return;
+    }
+
+    bg_pids[bg_head] = (sig_atomic_t)pid;
+    bg_statuses[bg_head] = (sig_atomic_t)status;
+    bg_head = next;
+}
+
+static void collect_exited_children(void)
+{
+    int saved_errno = errno;
+    int status;
+    pid_t pid;
+
+    while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
+        enqueue_bg_event(pid, status);
+    }
+
+    errno = saved_errno;
+}
+
+static void sigchld_handler(int signo)
+{
+    (void)signo;
+    collect_exited_children();
+}
+
+static int block_sigchld(sigset_t *oldmask)
+{
+    return sigprocmask(SIG_BLOCK, &sigchld_mask, oldmask);
+}
+
+static void restore_sigmask(const sigset_t *oldmask)
+{
+    sigprocmask(SIG_SETMASK, oldmask, NULL);
+}
 
 static char *expand_cd_target(const char *arg)
 {
@@ -125,6 +189,7 @@ static int builtin_exit(char **argv)
         code = (int)val;
     }
 
+    flush_background_events();
     log_msg("INFO", "shell exit (code=%d)", code);
     log_close();
     exit(code);
@@ -149,8 +214,10 @@ static void run_pipe_builtin(char **argv)
     }
 }
 
-static void pipe_child(int close_fd, int dup_fd, int target_fd, char **argv)
+static void pipe_child(int close_fd, int dup_fd, int target_fd, char **argv,
+                       const sigset_t *oldmask)
 {
+    restore_sigmask(oldmask);
     close(close_fd);
     if (dup2(dup_fd, target_fd) < 0) {
         perror("shell: dup2");
@@ -164,9 +231,10 @@ static void pipe_child(int close_fd, int dup_fd, int target_fd, char **argv)
     _exit(127);
 }
 
-static int log_process(pid_t pid, char **argv, const char *label, int set_exit)
+static int wait_for_child(pid_t pid, char **argv, const char *label, int set_exit)
 {
     int status = 0;
+
     if (waitpid(pid, &status, 0) < 0) {
         perror("shell: waitpid");
         log_msg("ERROR", "waitpid(%d) basarisiz: %s", (int)pid, strerror(errno));
@@ -186,12 +254,64 @@ static int log_process(pid_t pid, char **argv, const char *label, int set_exit)
     return 0;
 }
 
+int install_sigchld_handler(void)
+{
+    struct sigaction sa;
+
+    sigemptyset(&sigchld_mask);
+    sigaddset(&sigchld_mask, SIGCHLD);
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigchld_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_NOCLDSTOP;
+
+    return sigaction(SIGCHLD, &sa, NULL);
+}
+
+void flush_background_events(void)
+{
+    sigset_t oldmask;
+
+    if (block_sigchld(&oldmask) < 0) {
+        log_msg("ERROR", "sigprocmask basarisiz: %s", strerror(errno));
+        return;
+    }
+
+    collect_exited_children();
+
+    while (bg_tail != bg_head) {
+        pid_t pid = (pid_t)bg_pids[bg_tail];
+        int status = (int)bg_statuses[bg_tail];
+        bg_tail = (bg_tail + 1) % BG_EVENT_CAPACITY;
+
+        log_msg("INFO", "bg cmd bitti pid=%d exit=%d",
+                (int)pid, status_to_exit_code(status));
+    }
+
+    if (bg_overflow) {
+        log_msg("WARN", "bg event queue doldu, bazi cikislar loglanamamis olabilir");
+        bg_overflow = 0;
+    }
+
+    restore_sigmask(&oldmask);
+}
+
 int run_pipe(char **left_argv, char **right_argv)
 {
     int fd[2];
+    sigset_t oldmask;
+
+    if (block_sigchld(&oldmask) < 0) {
+        perror("shell: sigprocmask");
+        log_msg("ERROR", "sigprocmask basarisiz: %s", strerror(errno));
+        return -1;
+    }
+
     if (pipe(fd) < 0) {
         perror("shell: pipe");
         log_msg("ERROR", "pipe basarisiz: %s", strerror(errno));
+        restore_sigmask(&oldmask);
         return -1;
     }
 
@@ -201,11 +321,12 @@ int run_pipe(char **left_argv, char **right_argv)
         log_msg("ERROR", "fork basarisiz: %s", strerror(errno));
         close(fd[0]);
         close(fd[1]);
+        restore_sigmask(&oldmask);
         return -1;
     }
 
     if (left_pid == 0) {
-        pipe_child(fd[0], fd[1], STDOUT_FILENO, left_argv);
+        pipe_child(fd[0], fd[1], STDOUT_FILENO, left_argv, &oldmask);
     }
 
     pid_t right_pid = fork();
@@ -215,52 +336,85 @@ int run_pipe(char **left_argv, char **right_argv)
         close(fd[0]);
         close(fd[1]);
         waitpid(left_pid, NULL, 0);
+        restore_sigmask(&oldmask);
         return -1;
     }
 
     if (right_pid == 0) {
-        pipe_child(fd[1], fd[0], STDIN_FILENO, right_argv);
+        pipe_child(fd[1], fd[0], STDIN_FILENO, right_argv, &oldmask);
     }
 
     close(fd[0]);
     close(fd[1]);
 
-    log_process(left_pid, left_argv, "pipe-left: ", 0);
-    log_process(right_pid, right_argv, "pipe-right: ", 1);
+    wait_for_child(left_pid, left_argv, "pipe-left: ", 0);
+    wait_for_child(right_pid, right_argv, "pipe-right: ", 1);
+    restore_sigmask(&oldmask);
 
     return 0;
 }
 
-int run_builtin(char **argv)
+int run_builtin(char **argv, int background)
 {
     if (strcmp(argv[0], "cd") == 0) {
+        if (background) {
+            fprintf(stderr, "shell: built-in commands cannot run in background\n");
+            log_msg("WARN", "background built-in reddedildi: %s", argv[0]);
+            last_exit_code = 1;
+            return 1;
+        }
         builtin_cd(argv);
         return 1;
     }
     if (strcmp(argv[0], "exit") == 0) {
+        if (background) {
+            fprintf(stderr, "shell: built-in commands cannot run in background\n");
+            log_msg("WARN", "background built-in reddedildi: %s", argv[0]);
+            last_exit_code = 1;
+            return 1;
+        }
         builtin_exit(argv);
         return 1;
     }
     return 0;
 }
 
-int run_external(char **argv)
+int run_external(char **argv, int background)
 {
+    sigset_t oldmask;
+
+    if (block_sigchld(&oldmask) < 0) {
+        perror("shell: sigprocmask");
+        log_msg("ERROR", "sigprocmask basarisiz: %s", strerror(errno));
+        return -1;
+    }
+
     pid_t pid = fork();
     if (pid < 0) {
         perror("shell: fork");
         log_msg("ERROR", "fork basarisiz: %s", strerror(errno));
+        restore_sigmask(&oldmask);
         return -1;
     }
 
     if (pid == 0) {
+        restore_sigmask(&oldmask);
         execvp(argv[0], argv);
         fprintf(stderr, "shell: %s: %s\n", argv[0], strerror(errno));
         log_msg("ERROR", "execvp '%s' basarisiz: %s", argv[0], strerror(errno));
         _exit(127);
     }
 
-    if (log_process(pid, argv, "", 1) < 0)
-        return -1;
-    return 0;
+    if (background) {
+        printf("[%d]\n", (int)pid);
+        fflush(stdout);
+        log_msg("INFO", "bg cmd baslatildi pid=%d cmd='%s'", (int)pid, argv[0]);
+        last_exit_code = 0;
+        restore_sigmask(&oldmask);
+        return 0;
+    }
+
+    int rc = wait_for_child(pid, argv, "", 1);
+    restore_sigmask(&oldmask);
+    return rc;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,12 +1,12 @@
 #define _POSIX_C_SOURCE 200809L
 
+#include "executor.h"
 #include "log.h"
 #include "parser.h"
-#include "executor.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #define MAX_LINE 1024
@@ -15,8 +15,16 @@
 
 int main(void)
 {
+    int prompt_shown = 0;
+
     if (log_init(LOG_FILE) < 0) {
         perror("shell: log dosyasi acilamadi");
+        return EXIT_FAILURE;
+    }
+
+    if (install_sigchld_handler() < 0) {
+        perror("shell: SIGCHLD handler kurulamadi");
+        log_close();
         return EXIT_FAILURE;
     }
 
@@ -28,38 +36,55 @@ int main(void)
     char *right_argv[MAX_ARGS];
 
     for (;;) {
-        if (isatty(STDIN_FILENO)) {
+        flush_background_events();
+
+        if (isatty(STDIN_FILENO) && !prompt_shown) {
             fputs(PROMPT, stdout);
             fflush(stdout);
+            prompt_shown = 1;
         }
 
+        errno = 0;
         if (fgets(line, sizeof(line), stdin) == NULL) {
+            if (ferror(stdin) && errno == EINTR) {
+                clearerr(stdin);
+                flush_background_events();
+                continue;
+            }
             if (isatty(STDIN_FILENO)) fputc('\n', stdout);
             break;
         }
+        prompt_shown = 0;
 
-        int pres = parse_pipe(line, left_argv, right_argv);
+        int background = 0;
+        int pres = parse_pipe(line, left_argv, right_argv, &background);
         if (pres == -1) {
             fprintf(stderr, "shell: invalid pipe command\n");
             log_msg("ERROR", "invalid pipe, missing left or right command");
             continue;
         }
         if (pres == 1) {
+            if (background) {
+                fprintf(stderr, "shell: background pipe is not supported yet\n");
+                log_msg("WARN", "background pipe reddedildi");
+                continue;
+            }
             run_pipe(left_argv, right_argv);
             continue;
         }
 
-        if (parse_line(line, argv) == 0) {
+        if (parse_line(line, argv, &background) == 0) {
             continue;
         }
 
-        if (run_builtin(argv)) {
+        if (run_builtin(argv, background)) {
             continue;
         }
 
-        run_external(argv);
+        run_external(argv, background);
     }
 
+    flush_background_events();
     log_msg("INFO", "shell kapaniyor");
     log_close();
     return EXIT_SUCCESS;

--- a/src/parser.c
+++ b/src/parser.c
@@ -3,32 +3,56 @@
 #include <stdlib.h>
 #include <string.h>
 
-int parse_line(char *line, char **argv)
+int parse_line(char *line, char **argv, int *background)
 {
     int argc = 0;
+
+    if (background != NULL) {
+        *background = 0;
+    }
+
     char *tok = strtok(line, " \t\r\n");
     while (tok != NULL && argc < MAX_ARGS - 1) {
         argv[argc++] = tok;
         tok = strtok(NULL, " \t\r\n");
     }
+
+    if (argc > 0 && strcmp(argv[argc - 1], "&") == 0) {
+        argc--;
+        if (background != NULL) {
+            *background = 1;
+        }
+    }
+
     argv[argc] = NULL;
     return argc;
 }
 
-int parse_pipe(char *line, char **left_argv, char **right_argv)
+int parse_pipe(char *line, char **left_argv, char **right_argv, int *background)
 {
+    int left_background = 0;
+    int right_background = 0;
     char *pipe_pos = strchr(line, '|');
+
+    if (background != NULL) {
+        *background = 0;
+    }
+
     if (pipe_pos == NULL) {
         return 0;
     }
 
     *pipe_pos = '\0';
 
-    int left_argc  = parse_line(line, left_argv);
-    int right_argc = parse_line(pipe_pos + 1, right_argv);
+    int left_argc = parse_line(line, left_argv, &left_background);
+    int right_argc = parse_line(pipe_pos + 1, right_argv, &right_background);
 
     if (left_argc == 0 || right_argc == 0) {
         return -1;
+    }
+
+    if (background != NULL) {
+        *background = left_background || right_background;
     }
 
     return 1;


### PR DESCRIPTION
This pull request adds support for background process execution (`&`) and proper reaping of background children using `SIGCHLD`, while also updating the documentation, parser, and executor logic accordingly. It introduces a background event queue, ensures built-in commands cannot run in the background, and updates the REPL loop and test cases to reflect these new features.

**Background process and signal handling:**

* Added support for background execution (`&`) in the shell: external commands can now be run in the background, printing `[pid]` and immediately returning to the prompt (`src/executor.c`, `src/main.c`, `src/parser.c`). [[1]](diffhunk://#diff-82e93641c69d156d8545fd6e151ae896b218808b8d3d7332ea9faadf0ad738ffR16-R78) Fb9c6297L336R389, [[2]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccL6-R57) [[3]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L31-R87)
* Implemented `SIGCHLD` handler and a fixed-size background event queue to reap background children without leaving zombies; results are logged and flushed in the main loop (`src/executor.c`). [[1]](diffhunk://#diff-82e93641c69d156d8545fd6e151ae896b218808b8d3d7332ea9faadf0ad738ffR16-R78) [[2]](diffhunk://#diff-82e93641c69d156d8545fd6e151ae896b218808b8d3d7332ea9faadf0ad738ffR257-R314) [[3]](diffhunk://#diff-82e93641c69d156d8545fd6e151ae896b218808b8d3d7332ea9faadf0ad738ffR192) [[4]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L31-R87)
* Foreground commands temporarily block `SIGCHLD` to avoid race conditions with `waitpid`, ensuring robust process management (`src/executor.c`). [[1]](diffhunk://#diff-82e93641c69d156d8545fd6e151ae896b218808b8d3d7332ea9faadf0ad738ffR16-R78) [[2]](diffhunk://#diff-82e93641c69d156d8545fd6e151ae896b218808b8d3d7332ea9faadf0ad738ffR257-R314) Fb9c6297L336R389)

**Parser and executor API changes:**

* Modified parser and executor APIs to propagate background execution flags (`int background`), including changes to function signatures and logic in both parser and executor modules (`include/parser.h`, `include/executor.h`, `src/parser.c`, `src/executor.c`, `src/main.c`). [[1]](diffhunk://#diff-3b2df7c1bd222e92cf09a90765c2c75bf7353069fd6ff0ea90b4d5a280d0823bL6-R7) [[2]](diffhunk://#diff-ebeeb1fe20145bf0170ddb0dec8614a326c3861d14571e10e490aec2bc6752c5L4-R7) [[3]](diffhunk://#diff-3045e316fef9708ebd7095e9a191c711c5dd24e58cdb91c0961961463fabacccL6-R57) Fb9c6297L336R389, [[4]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L31-R87)

**Built-in and pipe command handling:**

* Built-in commands (`cd`, `exit`) are now explicitly disallowed from running in the background, with user feedback and log warnings; background pipes are also rejected with a warning (`src/executor.c`, `src/main.c`). (Fb9c6297L336R389, [src/main.cL31-R87](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L31-R87))
* Pipe execution is updated to properly mask/unmask `SIGCHLD` and propagate background flags, though background pipes are not yet supported (`src/executor.c`, `src/main.c`). [[1]](diffhunk://#diff-82e93641c69d156d8545fd6e151ae896b218808b8d3d7332ea9faadf0ad738ffR257-R314) [[2]](diffhunk://#diff-82e93641c69d156d8545fd6e151ae896b218808b8d3d7332ea9faadf0ad738ffR324-R329) [[3]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L31-R87)

**Documentation and test updates:**

* Updated `README.md` to document background process support, `SIGCHLD` handling, new test cases, and implementation details, including new manual and batch test scenarios. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R32) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R57) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R84-R87) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R118-R126) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R141-R151)

These changes collectively bring robust background process support and signal-safe reaping to the shell, while ensuring built-in commands and pipes are handled correctly with respect to background execution.

Closes #5 